### PR TITLE
Fixed git submodule init / update

### DIFF
--- a/graspit/CMakeLists.txt
+++ b/graspit/CMakeLists.txt
@@ -16,9 +16,9 @@ add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/graspit.pro
   COMMAND git submodule init
   COMMAND git submodule update
-  COMMAND patch -N -d graspit_source -p0 < graspit_project.patch
-  COMMAND patch -N -d graspit_source -p0 < graspit_dbase.patch
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND cd graspit && patch -N -d graspit_source -p0 < graspit_project.patch && cd ..
+  COMMAND cd graspit && patch -N -d graspit_source -p0 < graspit_dbase.patch && cd ..
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 add_custom_target(graspit_build ALL
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/graspit.pro


### PR DESCRIPTION
git submodule init and git submodule update must be run from the
root of the git working directory (e.g. folder with .git) with git version 1.7.9.5, which is default on Ubuntu 12.04.

Issue cannot be reproduced with git 1.9.1 (default on Ubuntu 14.04), because the new version of git is smart enough to find the root of the working directory.

@jvarley @mateiciocarlie 
