### PR TITLE
made graspit with cmake work with ros

### DIFF
--- a/graspit/CMakeLists.txt
+++ b/graspit/CMakeLists.txt
@@ -6,6 +6,12 @@ set(PACKAGE_DEPS
 
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPS})
 
+
+catkin_package(
+  CATKIN_DEPENDS ${PACKAGE_DEPS}
+  INCLUDE_DIRS . graspit_source graspit_source/include/
+)
+
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/CMakeLists.txt
   COMMAND git submodule init
@@ -21,11 +27,6 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/include)
 include_directories(${catkin_INCLUDE_DIRS})
 
 add_subdirectory(graspit_source)
-
-catkin_package(
-  CATKIN_DEPENDS ${PACKAGE_DEPS}
-  INCLUDE_DIRS . graspit_source graspit_source/include/
-)
 
 install(DIRECTORY graspit_source/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/graspit/CMakeLists.txt
+++ b/graspit/CMakeLists.txt
@@ -4,26 +4,10 @@ project(graspit)
 set(PACKAGE_DEPS
 )
 
-include(ProcessorCount)
-if(DEFINED PROCESSOR_COUNT)
-    ProcessorCount(N)
-else()
-    set(N 4)
-endif()
-
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPS})
-find_program(HAVE_QMAKE_QT_4 qmake-qt4)
-
-if(HAVE_QMAKE_QT_4)
-  set(QMAKE_COMMAND qmake-qt4)
-else(NOT HAVE_QMAKE_QT_4)
-  set(QMAKE_COMMAND qmake)
-endif(HAVE_QMAKE_QT_4)
-message("GraspIt built with ${QMAKE_COMMAND}")
-
 
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/graspit.pro
+  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/CMakeLists.txt
   COMMAND git submodule init
   COMMAND git submodule update
   COMMAND cd graspit && patch -N -d graspit_source -p0 < graspit_project.patch && cd ..
@@ -35,11 +19,8 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/include)
 
 include_directories(${catkin_INCLUDE_DIRS})
-add_custom_target(graspit_build ALL
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/graspit.pro
-  COMMAND ${QMAKE_COMMAND}  "EXT_DESTDIR = ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}" ${CMAKE_CURRENT_SOURCE_DIR}/graspit_source/graspit.pro
-  COMMAND make -j${N}
-)
+
+add_subdirectory(graspit_source)
 
 catkin_package(
   CATKIN_DEPENDS ${PACKAGE_DEPS}


### PR DESCRIPTION
@mateiciocarlie 

This is NOT ready to be pulled in. 

I deleted graspit_source, and cloned the cmake version of graspit into graspit_source , and then ran catkin_make

I tested this in a workspace with the following:
https://github.com/CURG/graspit_msgs
https://github.com/CURG/graspit_moveit_plugin

With this PR, everything builds fine, but graspit_simulator executable is placed in 
./build/graspit-ros/graspit/graspit_source/graspit_simulator
which is not correct.  I am still determining how to fix this.  Besides that though, the plugins compile and run fine. 
